### PR TITLE
Feature/enable mavlink2 on receive stream

### DIFF
--- a/src/mavlink_vehicle_manager.cpp
+++ b/src/mavlink_vehicle_manager.cpp
@@ -489,7 +489,7 @@ Mavlink_vehicle_manager::On_stream_read(
     if (mav_stream->Get_stream()) {
         if (result == Io_result::OK) {
             mav_stream->Get_decoder().Decode(buffer);
-            if (mav_stream->Get_decoder().Is_mavlink_v2()
+            if (mav_stream->Get_decoder().Get_mavlink_version() == Mavlink_decoder::MavlinkVersion::V2
                 && !mav_stream->Is_mavlink_v2())
             {
                 mav_stream->Set_mavlink_v2(true);

--- a/src/mavlink_vehicle_manager.cpp
+++ b/src/mavlink_vehicle_manager.cpp
@@ -489,7 +489,7 @@ Mavlink_vehicle_manager::On_stream_read(
     if (mav_stream->Get_stream()) {
         if (result == Io_result::OK) {
             mav_stream->Get_decoder().Decode(buffer);
-            if (mav_stream->Get_decoder().Is_mavlink2()
+            if (mav_stream->Get_decoder().Is_mavlink_v2()
                 && !mav_stream->Is_mavlink_v2())
             {
                 mav_stream->Set_mavlink_v2(true);

--- a/src/mavlink_vehicle_manager.cpp
+++ b/src/mavlink_vehicle_manager.cpp
@@ -489,6 +489,12 @@ Mavlink_vehicle_manager::On_stream_read(
     if (mav_stream->Get_stream()) {
         if (result == Io_result::OK) {
             mav_stream->Get_decoder().Decode(buffer);
+            if (mav_stream->Get_decoder().Is_mavlink2()
+                && !mav_stream->Is_mavlink_v2())
+            {
+                mav_stream->Set_mavlink_v2(true);
+                LOG_DEBUG("Enabled MAVLINK2 on received mavlink2 stream data.");
+            }
             Schedule_next_read(mav_stream);
         } else {
             /* Stream error during detection. */


### PR DESCRIPTION
機体からのMavlinkメッセージフォーマットがMAVLink 2である場合、GCS側からDrone側に送信するmavlink protocolをMAVLink 2に切替します。